### PR TITLE
Make server connectivity much more solid

### DIFF
--- a/src/autoload/MultiplayerInfo.gd
+++ b/src/autoload/MultiplayerInfo.gd
@@ -44,7 +44,6 @@ func _connected_ok():
 
 
 func _server_disconnected():
-	print("Server disconnected")
 	OS.alert("Server disconnected")
 	get_tree().network_peer = null
 	player_info = {}
@@ -55,7 +54,6 @@ func _server_disconnected():
 
 
 func _connected_fail():
-	print("Connection failed")
 	OS.alert("Could not connect to server!")
 	var menu := get_tree().get_root().get_node_or_null("Menu") as Node
 	if menu:

--- a/src/objects/Player.gd
+++ b/src/objects/Player.gd
@@ -30,29 +30,7 @@ func _unhandled_input(event: InputEvent) -> void:
 	if not should_control():
 		return
 	if event is InputEventMouseMotion:
-		var mm_event := event as InputEventMouseMotion
-		var relative := mm_event.relative
-
-		var window_size := OS.get_window_size()
-		var base_size := Vector2(
-				ProjectSettings.get_setting("display/window/size/width"),
-				ProjectSettings.get_setting("display/window/size/height")
-		)
-
-		# Because of the 2D scaling mode, the game "scales" our mouse input to match the current window size. That means
-		# if you make the window bigger, your mouse inputs will be relatively smaller. We don't want this, since that
-		# doesn't make sense for 3D mouse look. So here, we "un-scale" it back to normal
-		var scale := min(
-				float(window_size.x) / float(base_size.x),
-				float(window_size.y) / float(base_size.y)
-		)
-		relative *= scale
-		# Correct any rounding error
-		relative.x = round(relative.x)
-		relative.y = round(relative.y)
-
-		rotation.y = wrapf(rotation.y - relative.x * MOUSE_SENS.x, 0, TAU)
-		camera.rotation.x = clamp(camera.rotation.x - relative.y * MOUSE_SENS.y, -PI / 2, PI / 2)
+		handle_mouse_movement(event as InputEventMouseMotion)
 		get_tree().set_input_as_handled()
 	elif event.is_action_pressed("shoot"):
 		if is_active:
@@ -101,6 +79,31 @@ func _physics_process(delta: float) -> void:
 remote func set_network_transform(new_translation: Vector3, new_rotation: Vector3):
 	translation = new_translation
 	rotation = new_rotation
+
+
+func handle_mouse_movement(event: InputEventMouseMotion) -> void:
+	var relative := event.relative
+
+	var window_size := OS.get_window_size()
+	var base_size := Vector2(
+			ProjectSettings.get_setting("display/window/size/width"),
+			ProjectSettings.get_setting("display/window/size/height")
+	)
+
+	# Because of the 2D scaling mode, the game "scales" our mouse input to match the current window size. That means
+	# if you make the window bigger, your mouse inputs will be relatively smaller. We don't want this, since that
+	# doesn't make sense for 3D mouse look. So here, we "un-scale" it back to normal
+	var scale := min(
+			float(window_size.x) / float(base_size.x),
+			float(window_size.y) / float(base_size.y)
+	)
+	relative *= scale
+	# Correct any rounding error
+	relative.x = round(relative.x)
+	relative.y = round(relative.y)
+
+	rotation.y = wrapf(rotation.y - relative.x * MOUSE_SENS.x, 0, TAU)
+	camera.rotation.x = clamp(camera.rotation.x - relative.y * MOUSE_SENS.y, -PI / 2, PI / 2)
 
 
 func on_raycast_hit(_peer_id: int):

--- a/src/states/Game.gd
+++ b/src/states/Game.gd
@@ -99,11 +99,11 @@ func spawn_player() -> void:
 		my_player.set_network_master(self_peer_id)
 	my_player.get_node("Camera").current = true
 	my_player.translation = get_node("Level/PlayerSpawnPoint").translation
-	get_node("Players").add_child(my_player)
+	$Players.add_child(my_player)
 	Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
 
 
-remote func spawn_peer_player(player_id) -> void:
+remote func spawn_peer_player(player_id: int) -> void:
 	var player := preload("res://src/objects/Player.tscn").instance() as KinematicBody
 	var player_info = MultiplayerInfo.player_info[player_id]
 	player.set_name(str(player_id))
@@ -113,4 +113,11 @@ remote func spawn_peer_player(player_id) -> void:
 	material.albedo_color = player_info.favorite_color
 	mesh_instance.mesh.surface_set_material(0, material)
 	player.set_network_master(player_id)
-	get_node("Players").add_child(player)
+	$Players.add_child(player)
+
+
+func remove_peer_player(player_id: int) -> void:
+	var player := $Players.get_node(str(player_id))
+	if player:
+		$Players.remove_child(player)
+	$UI/Scoreboard.remove_player(player_id)

--- a/src/states/Menu.gd
+++ b/src/states/Menu.gd
@@ -6,6 +6,12 @@ onready var address_line_edit := $"%IpLineEdit" as LineEdit
 onready var port_spin_box := $"%PortSpinBox" as SpinBox
 onready var color_picker_button := $"%ColorPickerButton" as ColorPickerButton
 
+onready var host_button := $"%HostButton" as Button
+onready var join_button := $"%JoinButton" as Button
+onready var free_play_button := $"%FreePlayButton" as Button
+onready var credits_button := $"%CreditsButton" as Button
+
+
 
 func play() -> void:
 	var error := get_tree().change_scene("res://src/states/Game.tscn")
@@ -16,17 +22,44 @@ func host_session() -> void:
 	MultiplayerInfo.my_info.name = name_line_edit.text
 	MultiplayerInfo.my_info.favorite_color = color_picker_button.color
 	var peer := NetworkedMultiplayerENet.new()
-	peer.create_server(port_spin_box.value, 4)
+	# warning-ignore:narrowing_conversion
+	var error := peer.create_server(port_spin_box.value, 4)
+	if error:
+		OS.alert("Could not create server!")
+		return
 	get_tree().network_peer = peer
 	play()
+
+
+func disable_play_buttons() -> void:
+	host_button.disabled = true
+	join_button.disabled = true
+	free_play_button.disabled = true
+	credits_button.disabled = true
+
+
+func enable_play_buttons() -> void:
+	host_button.disabled = false
+	join_button.disabled = false
+	free_play_button.disabled = false
+	credits_button.disabled = false
 
 
 func join_session() -> void:
 	MultiplayerInfo.my_info.name = name_line_edit.text
 	MultiplayerInfo.my_info.favorite_color = color_picker_button.color
 	var peer := NetworkedMultiplayerENet.new()
-	peer.create_client(address_line_edit.text, port_spin_box.value)
+	# warning-ignore:narrowing_conversion
+	var error := peer.create_client(address_line_edit.text, port_spin_box.value)
+	if error:
+		OS.alert("Could not create client!")
+		return
+	disable_play_buttons()
 	get_tree().network_peer = peer
+	# Wait until MultiplayerInfo gets a connection_ok to join, at which point call "session_joined"
+
+
+func session_joined() -> void:
 	play()
 	rpc("Game.spawn_peer_player", get_tree().get_network_unique_id())
 

--- a/src/states/Menu.gd
+++ b/src/states/Menu.gd
@@ -61,7 +61,6 @@ func join_session() -> void:
 
 func session_joined() -> void:
 	play()
-	rpc("Game.spawn_peer_player", get_tree().get_network_unique_id())
 
 
 func free_play_session() -> void:

--- a/src/states/Menu.tscn
+++ b/src/states/Menu.tscn
@@ -128,12 +128,14 @@ margin_bottom = 188.0
 custom_constants/separation = 12
 
 [node name="HostButton" type="Button" parent="V/V/H"]
+unique_name_in_owner = true
 margin_right = 144.0
 margin_bottom = 38.0
 size_flags_horizontal = 3
 text = "Host"
 
 [node name="JoinButton" type="Button" parent="V/V/H"]
+unique_name_in_owner = true
 margin_left = 156.0
 margin_right = 300.0
 margin_bottom = 38.0
@@ -141,12 +143,14 @@ size_flags_horizontal = 3
 text = "Join"
 
 [node name="FreePlayButton" type="Button" parent="V/V"]
+unique_name_in_owner = true
 margin_top = 200.0
 margin_right = 300.0
 margin_bottom = 238.0
 text = "Free Play"
 
 [node name="CreditsButton" type="Button" parent="V/V"]
+unique_name_in_owner = true
 margin_top = 250.0
 margin_right = 300.0
 margin_bottom = 288.0

--- a/src/states/PauseMenu.gd
+++ b/src/states/PauseMenu.gd
@@ -7,6 +7,8 @@ onready var disconnect_button := $"%DisconnectButton" as Button
 func _ready() -> void:
 	if get_tree().is_network_server():
 		disconnect_button.text = "Stop Hosting"
+	if not get_tree().network_peer:
+		disconnect_button.text = "Quit Free Play"
 
 
 func open_menu() -> void:
@@ -22,5 +24,6 @@ func close_menu() -> void:
 func disconnect_from_server() -> void:
 	Input.mouse_mode = Input.MOUSE_MODE_VISIBLE
 	get_tree().network_peer = null
+	MultiplayerInfo.player_info = {}
 	var error := get_tree().change_scene("res://src/states/Menu.tscn")
 	assert(not error)


### PR DESCRIPTION
Despite being branch `hth3-interpolation` I didn't do any interpolation shit lmao
* When creating a server, bail with an error if the server can't be created (e.x. port in use)
* When joining a server, bail out if a connection can't be created
* If the server disconnects, clients get booted back to the menu