### PR TITLE
Fix intermittent RPC errors when targets get hit

### DIFF
--- a/src/objects/target.gd
+++ b/src/objects/target.gd
@@ -8,7 +8,6 @@ signal target_destroyed
 func on_raycast_hit(player_id: int) -> void:
 	if get_multiplayer().has_multiplayer_peer():
 		rpc("destroy_self", player_id)
-	destroy_self(player_id)
 
 
 @rpc("any_peer", "call_local")
@@ -21,8 +20,6 @@ func handle_hit(player_id: int) -> void:
 	if get_multiplayer().has_multiplayer_peer():
 		if get_multiplayer().is_server():
 			rpc("destroy_self", player_id)
-		else:
-			destroy_self(player_id)
 
 
 func on_body_hit(body: Node) -> void:


### PR DESCRIPTION
The branch name is a misnomer, there weren't any desyncs - it just was sometimes destroying the target multiple times