### PR TITLE
Fix volume not applying on game load or to punches

### DIFF
--- a/src/autoload/global.gd
+++ b/src/autoload/global.gd
@@ -68,6 +68,8 @@ func load_config() -> void:
 				new_value = int(clamp(new_value, 2, 8))
 			config[key] = new_value
 
+	Global.update_volume()
+
 
 func save_config() -> void:
 	var config_file = FileAccess.open(CONFIG_PATH, FileAccess.WRITE)

--- a/src/objects/player.tscn
+++ b/src/objects/player.tscn
@@ -152,12 +152,15 @@ unique_name_in_owner = true
 
 [node name="1" type="AudioStreamPlayer3D" parent="Sound/Punching"]
 stream = ExtResource("10_iubme")
+bus = &"SFX"
 
 [node name="2" type="AudioStreamPlayer3D" parent="Sound/Punching"]
 stream = ExtResource("11_5kqe2")
+bus = &"SFX"
 
 [node name="3" type="AudioStreamPlayer3D" parent="Sound/Punching"]
 stream = ExtResource("12_eblis")
+bus = &"SFX"
 
 [connection signal="area_entered" from="Hurtbox" to="." method="on_punched"]
 [connection signal="body_entered" from="Hurtbox" to="." method="on_shot"]


### PR DESCRIPTION
Misc volume fixes:

* Punches weren't affected by the volume slider since they weren't on the SFX bus
* After loading the game, you needed to nudge the volume slider to get the volume to change since it wasn't updating the volume after loading the config