### PR TITLE
Add better spawn points.

### DIFF
--- a/src/levels/arena.tscn
+++ b/src/levels/arena.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=6 format=3 uid="uid://comegerv7kpdp"]
+[gd_scene load_steps=7 format=3 uid="uid://comegerv7kpdp"]
 
 [ext_resource type="PackedScene" uid="uid://bv7bliqu5vy4w" path="res://src/levels/geometry/arena.tscn" id="1_wx3bi"]
 [ext_resource type="PackedScene" uid="uid://dsa72p11ys28g" path="res://src/objects/target.tscn" id="2_r6q6b"]
+[ext_resource type="PackedScene" uid="uid://lrk6kkcr456q" path="res://src/objects/spawn_point.tscn" id="3_dgmbr"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_v2xil"]
 sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
@@ -332,23 +333,23 @@ metadata/_edit_lock_ = true
 
 [node name="SpawnPoints" type="Node" parent="."]
 
-[node name="Marker3D" type="Marker3D" parent="SpawnPoints" groups=["SpawnPoints"]]
-transform = Transform3D(0.0788245, 0, -0.996889, 0, 1, 0, 0.996889, 0, 0.0788245, -19.0417, 1.62991, 0.54702)
+[node name="SpawnPoint" parent="SpawnPoints" instance=ExtResource("3_dgmbr")]
+transform = Transform3D(-0.866025, 0, 0.5, 0, 1, 0, -0.5, 0, -0.866025, 9.602, 2, -16.052)
 
-[node name="Marker3D2" type="Marker3D" parent="SpawnPoints" groups=["SpawnPoints"]]
-transform = Transform3D(-0.844562, 0, -0.535458, 0, 1, 0, 0.535458, 0, -0.844562, -9.16162, 6.64196, -16.5584)
+[node name="SpawnPoint2" parent="SpawnPoints" instance=ExtResource("3_dgmbr")]
+transform = Transform3D(-4.37114e-08, 0, 1, 0, 1, 0, -1, 0, -4.37114e-08, 18.1607, 8, 0.0885324)
 
-[node name="Marker3D3" type="Marker3D" parent="SpawnPoints" groups=["SpawnPoints"]]
-transform = Transform3D(-0.850921, 0, 0.525294, 0, 1, 0, -0.525294, 0, -0.850921, 9.19717, 0.735681, -15.3922)
+[node name="SpawnPoint3" parent="SpawnPoints" instance=ExtResource("3_dgmbr")]
+transform = Transform3D(0.866025, 0, 0.5, 0, 1, 0, -0.5, 0, 0.866025, 9.16377, 2, 16.1062)
 
-[node name="Marker3D4" type="Marker3D" parent="SpawnPoints" groups=["SpawnPoints"]]
-transform = Transform3D(-0.0291425, 0, 0.999575, 0, 1, 0, -0.999575, 0, -0.0291426, 18.6721, 6.64196, -0.284459)
+[node name="SpawnPoint4" parent="SpawnPoints" instance=ExtResource("3_dgmbr")]
+transform = Transform3D(0.866025, 0, -0.5, 0, 1, 0, 0.5, 0, 0.866025, -9.50334, 8, 16.3705)
 
-[node name="Marker3D5" type="Marker3D" parent="SpawnPoints" groups=["SpawnPoints"]]
-transform = Transform3D(0.872001, 0, 0.489504, 0, 1, 0, -0.489504, 0, 0.872001, 9.70162, 0.735681, 15.9137)
+[node name="SpawnPoint5" parent="SpawnPoints" instance=ExtResource("3_dgmbr")]
+transform = Transform3D(1.31134e-07, 0, -1, 0, 1, 0, 1, 0, 1.31134e-07, -18.5, 2, 2.08165e-12)
 
-[node name="Marker3D6" type="Marker3D" parent="SpawnPoints" groups=["SpawnPoints"]]
-transform = Transform3D(0.861456, -0.00206076, -0.507828, 0.00249295, 0.999997, 0.000170948, 0.507826, -0.00141325, 0.861459, -8.88837, 6.65354, 15.3956)
+[node name="SpawnPoint6" parent="SpawnPoints" instance=ExtResource("3_dgmbr")]
+transform = Transform3D(-0.866025, 0, -0.5, 0, 1, 0, 0.5, 0, -0.866025, -9.11922, 8, -15.8523)
 
 [node name="SpectatorCamera" type="Camera3D" parent="."]
 transform = Transform3D(1, -6.97574e-16, -1.5246e-23, -1.5246e-23, -4.37114e-08, 1, -6.97574e-16, -1, -4.37114e-08, 2.08165e-12, 50, 2.08165e-12)

--- a/src/levels/preview_level.gd
+++ b/src/levels/preview_level.gd
@@ -13,6 +13,7 @@ extends Node3D
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
+	running = true
 	# Despawn all the targets.
 	var nodes := get_tree().get_nodes_in_group("Targets") as Array
 	nodes = Utils.shuffle(nodes)

--- a/src/levels/preview_level.gd
+++ b/src/levels/preview_level.gd
@@ -2,9 +2,9 @@
 extends Node3D
 
 
-@export var running: bool = false
 @export var pan_circle_center: Vector3 = Vector3(0, 20, 0)
 @export var pan_circle_radius: float = 12.5
+@export_range(0, 360) var pan_angle: float = 0
 @export_range(0, 90) var angle_of_depression: float = 0
 
 
@@ -13,24 +13,26 @@ extends Node3D
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	running = true
 	# Despawn all the targets.
 	var nodes := get_tree().get_nodes_in_group("Targets") as Array
 	nodes = Utils.shuffle(nodes)
 	for idx in range(len(nodes) - 6):
 		nodes[idx].queue_free()
-	var pan := get_tree().create_tween()
-	pan.bind_node(self)
-	pan.set_trans(Tween.TRANS_LINEAR)
-	pan.set_loops()
-	pan.tween_method(self.set_camera_transform, 0.0, 2 * PI, 30.0)
-	pan.play()
+	if not Engine.is_editor_hint():
+		var pan := get_tree().create_tween()
+		pan.bind_node(self)
+		pan.set_trans(Tween.TRANS_LINEAR)
+		pan.set_loops()
+		pan.tween_method(self.set_pan_angle, 0.0, 360.0, 30.0)
+		pan.play()
 
 
-func set_camera_transform(angle: float) -> void:
-	if running:
-		camera.position = pan_circle_center + pan_circle_radius * Vector3(cos(angle), 0.0, -sin(angle))
-		camera.rotation = Vector3(deg_to_rad(-angle_of_depression), angle + PI/2, 0.0)
-	else:
-		camera.position = pan_circle_center + pan_circle_radius * Vector3.RIGHT
-		camera.rotation = Vector3(deg_to_rad(-angle_of_depression), PI/2, 0.0)
+func _process(_delta):
+	var pan_angle_rad = deg_to_rad(pan_angle)
+	var towards_center := Vector3(cos(pan_angle_rad), 0.0, -sin(pan_angle_rad))
+	camera.position = pan_circle_center + pan_circle_radius * towards_center
+	camera.rotation = Vector3(deg_to_rad(-angle_of_depression), pan_angle_rad + PI/2, 0.0)
+
+
+func set_pan_angle(angle: float):
+	pan_angle = angle

--- a/src/levels/preview_level.gd
+++ b/src/levels/preview_level.gd
@@ -1,9 +1,11 @@
+@tool
 extends Node3D
 
 
-const PAN_CIRCLE_CENTER: Vector3 = Vector3(0, 20, 0)
-const PAN_CIRCLE_RADIUS: float = 12.5
-const ANGLE_OF_DEPRESSION: float = deg_to_rad(-35)
+@export var running: bool = false
+@export var pan_circle_center: Vector3 = Vector3(0, 20, 0)
+@export var pan_circle_radius: float = 12.5
+@export_range(0, 90) var angle_of_depression: float = 0
 
 
 @onready var camera: Camera3D = %Camera3D
@@ -25,5 +27,9 @@ func _ready() -> void:
 
 
 func set_camera_transform(angle: float) -> void:
-	camera.position = PAN_CIRCLE_CENTER + PAN_CIRCLE_RADIUS * Vector3(cos(angle), 0.0, -sin(angle))
-	camera.rotation = Vector3(ANGLE_OF_DEPRESSION, angle + PI/2, 0.0)
+	if running:
+		camera.position = pan_circle_center + pan_circle_radius * Vector3(cos(angle), 0.0, -sin(angle))
+		camera.rotation = Vector3(deg_to_rad(-angle_of_depression), angle + PI/2, 0.0)
+	else:
+		camera.position = pan_circle_center + pan_circle_radius * Vector3.RIGHT
+		camera.rotation = Vector3(deg_to_rad(-angle_of_depression), PI/2, 0.0)

--- a/src/levels/preview_level.tscn
+++ b/src/levels/preview_level.tscn
@@ -5,10 +5,12 @@
 
 [node name="PreviewLevel" type="Node3D"]
 script = ExtResource("2")
+pan_circle_center = Vector3(2.08165e-12, 13.5, 2.08165e-12)
+angle_of_depression = 35.0
 
 [node name="Arena" parent="." instance=ExtResource("2_mk7xo")]
 
 [node name="Camera3D" type="Camera3D" parent="."]
 unique_name_in_owner = true
-transform = Transform3D(1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 20, 0)
+transform = Transform3D(-4.37114e-08, -0.573576, 0.819152, 0, 0.819152, 0.573576, -1, 2.50718e-08, -3.58063e-08, 12.5, 13.5, 2.08165e-12)
 current = true

--- a/src/objects/player.gd
+++ b/src/objects/player.gd
@@ -4,6 +4,7 @@ class_name Player
 
 signal melee_attack
 signal shoot
+signal player_spawn
 signal player_death
 
 
@@ -255,6 +256,7 @@ func on_punched(area: Node) -> void:
 
 
 func on_respawn() -> void:
+	emit_signal("player_spawn")
 	is_active = true
 	get_tree().create_timer(IFRAME_TIME).timeout.connect(self.set_vulnerable.bind(true))
 

--- a/src/objects/spawn_point.gd
+++ b/src/objects/spawn_point.gd
@@ -6,7 +6,7 @@ class_name SpawnPoint
 
 
 # The player currently associated with this spawn point, or -1 if there are no players.
-var player_id: int = -1
+var assigned_player_id: int = -1
 
 
 func _ready():
@@ -16,11 +16,14 @@ func _ready():
 # Returns true if there are no players (except possibly the player that is spawning) within the
 # exclusion zone.
 # :param player_id: The player that is spawning.
-func available(_player_id: int) -> bool:
+func available(player_id: int) -> bool:
+	# If this spawn point is already assigned to someone, it is not available.
+	if assigned_player_id != -1:
+		return false
 	var players_in_zone := exclusion_zone.get_overlapping_bodies() as Array[Node3D]
 	if len(players_in_zone) == 0:
 		return true
-	elif len(players_in_zone) == 1 and players_in_zone[0].name == str(_player_id):
+	elif len(players_in_zone) == 1 and players_in_zone[0].name == str(player_id):
 		return true
 	else:
 		return false

--- a/src/objects/spawn_point.gd
+++ b/src/objects/spawn_point.gd
@@ -1,0 +1,26 @@
+extends Node3D
+class_name SpawnPoint
+
+
+@onready var exclusion_zone = $ExclusionZone
+
+
+# The player currently associated with this spawn point, or -1 if there are no players.
+var player_id: int = -1
+
+
+func _ready():
+	hide()
+
+
+# Returns true if there are no players (except possibly the player that is spawning) within the
+# exclusion zone.
+# :param player_id: The player that is spawning.
+func available(_player_id: int) -> bool:
+	var players_in_zone := exclusion_zone.get_overlapping_bodies() as Array[Node3D]
+	if len(players_in_zone) == 0:
+		return true
+	elif len(players_in_zone) == 1 and players_in_zone[0].name == str(_player_id):
+		return true
+	else:
+		return false

--- a/src/objects/spawn_point.tscn
+++ b/src/objects/spawn_point.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=4 format=3 uid="uid://lrk6kkcr456q"]
+
+[ext_resource type="Script" path="res://src/objects/spawn_point.gd" id="1_yhi5r"]
+
+[sub_resource type="CylinderMesh" id="CylinderMesh_6q58o"]
+top_radius = 0.0
+bottom_radius = 0.25
+height = 0.5
+
+[sub_resource type="CylinderShape3D" id="CylinderShape3D_rfyo3"]
+height = 3.0
+radius = 5.0
+
+[node name="SpawnPoint" type="Node3D" groups=["SpawnPoints"]]
+script = ExtResource("1_yhi5r")
+
+[node name="Indicator" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, -6.97574e-16, -1.5246e-23, -1.5246e-23, -4.37114e-08, 1, -6.97574e-16, -1, -4.37114e-08, 2.08165e-12, 2.08165e-12, -0.25)
+mesh = SubResource("CylinderMesh_6q58o")
+
+[node name="ExclusionZone" type="Area3D" parent="."]
+collision_layer = 0
+collision_mask = 2
+monitorable = false
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="ExclusionZone"]
+shape = SubResource("CylinderShape3D_rfyo3")

--- a/src/states/game.gd
+++ b/src/states/game.gd
@@ -231,6 +231,8 @@ func assign_spawn_point(player_id: int) -> void:
 		spawn_point = assigned_spawn_points.pick_random()
 	else:
 		var available_spawn_points := spawn_points.filter(func(x): return x.available(player_id))
+		if len(available_spawn_points) == 0:
+			available_spawn_points = spawn_points
 		spawn_point = available_spawn_points.pick_random() as SpawnPoint
 	spawn_point.player_id = player_id
 	rpc_id(player_id, "move_to_spawn_point", spawn_point.transform)

--- a/src/states/game.gd
+++ b/src/states/game.gd
@@ -226,7 +226,9 @@ func assign_spawn_point(player_id: int) -> void:
 	print("Assigning spawn point to player %d" % player_id)
 	var spawn_point: SpawnPoint
 	# Check if there are any pre-assigned spawn points for this player.
-	var assigned_spawn_points := spawn_points.filter(func(x): return x.player_id == player_id)
+	var assigned_spawn_points := spawn_points.filter(
+		func(x): return x.assigned_player_id == player_id
+	)
 	if len(assigned_spawn_points) > 0:
 		spawn_point = assigned_spawn_points.pick_random()
 	else:
@@ -234,7 +236,7 @@ func assign_spawn_point(player_id: int) -> void:
 		if len(available_spawn_points) == 0:
 			available_spawn_points = spawn_points
 		spawn_point = available_spawn_points.pick_random() as SpawnPoint
-	spawn_point.player_id = player_id
+	spawn_point.assigned_player_id = player_id
 	rpc_id(player_id, "move_to_spawn_point", spawn_point.transform)
 
 
@@ -242,7 +244,9 @@ func clear_spawn_point(player_id: int) -> void:
 	if not is_multiplayer_authority():
 		return
 	if Multiplayer.game_mode == Multiplayer.GameMode.FFA:
-		var assigned_spawn_points := spawn_points.filter(func(x): return x.player_id == player_id)
+		var assigned_spawn_points := spawn_points.filter(
+			func(x): return x.assigned_player_id == player_id
+		)
 		for spawn_point in assigned_spawn_points:
 			spawn_point.player_id = -1
 

--- a/src/states/menus/menu.tscn
+++ b/src/states/menus/menu.tscn
@@ -19,6 +19,7 @@ script = ExtResource("1_m0gmu")
 layer = -2
 
 [node name="PreviewLevel" parent="CanvasLayer" instance=ExtResource("5")]
+pan_angle = null
 
 [node name="ColorRect" type="ColorRect" parent="CanvasLayer"]
 anchors_preset = 15


### PR DESCRIPTION
Spawn points have been reworked:
- They are always in the right node group now
- Can set initial rotation as well as position
- Have indicators for the 3D preview
- Properly exclude players (no more spawning on top of each other)

In addition the preview level was made customizable (try it out in the editor!)

Future work:
- Make spawn points assigned to specific teams for team mode (and don't clear them on spawn)
- Fix the original level