### PR TITLE
Small improvements and cleanups

### DIFF
--- a/src/autoload/multiplayer.gd
+++ b/src/autoload/multiplayer.gd
@@ -54,11 +54,11 @@ var exit_timer := Timer.new()
 
 
 func _ready():
-	get_multiplayer().peer_connected.connect(self._player_connected)
-	get_multiplayer().peer_disconnected.connect(self._player_disconnected)
-	get_multiplayer().connected_to_server.connect(self._connected_ok)
-	get_multiplayer().connection_failed.connect(self._connected_fail)
-	get_multiplayer().server_disconnected.connect(self._server_disconnected)
+	get_multiplayer().peer_connected.connect(_player_connected)
+	get_multiplayer().peer_disconnected.connect(_player_disconnected)
+	get_multiplayer().connected_to_server.connect(_connected_ok)
+	get_multiplayer().connection_failed.connect(_connected_fail)
+	get_multiplayer().server_disconnected.connect(_server_disconnected)
 	add_child(exit_timer)
 	exit_timer.timeout.connect(quit_dedicated_server)
 

--- a/src/levels/preview_level.gd
+++ b/src/levels/preview_level.gd
@@ -23,7 +23,7 @@ func _ready() -> void:
 		pan.bind_node(self)
 		pan.set_trans(Tween.TRANS_LINEAR)
 		pan.set_loops()
-		pan.tween_method(self.set_pan_angle, 0.0, 360.0, 30.0)
+		pan.tween_method(set_pan_angle, 0.0, 360.0, 30.0)
 		pan.play()
 
 

--- a/src/levels/preview_level.gd
+++ b/src/levels/preview_level.gd
@@ -19,7 +19,7 @@ func _ready() -> void:
 	for idx in range(len(nodes) - 6):
 		nodes[idx].queue_free()
 	if not Engine.is_editor_hint():
-		var pan := get_tree().create_tween()
+		var pan := create_tween()
 		pan.bind_node(self)
 		pan.set_trans(Tween.TRANS_LINEAR)
 		pan.set_loops()

--- a/src/objects/player.gd
+++ b/src/objects/player.gd
@@ -248,7 +248,7 @@ func on_raycast_hit(peer_id: int):
 func ive_been_hit():
 	$Blood.emitting = true
 	emit_signal("player_death")
-	get_tree().create_timer(RESPAWN_TIME).timeout.connect(self.on_respawn)
+	get_tree().create_timer(RESPAWN_TIME).timeout.connect(on_respawn)
 	state = PlayerState.SPAWNING
 	set_vulnerable(false)
 
@@ -283,7 +283,7 @@ func on_death_barrier() -> void:
 func on_respawn() -> void:
 	emit_signal("player_spawn")
 	state = PlayerState.NORMAL
-	get_tree().create_timer(IFRAME_TIME).timeout.connect(self.set_vulnerable.bind(true))
+	get_tree().create_timer(IFRAME_TIME).timeout.connect(set_vulnerable.bind(true))
 
 
 func set_vulnerable(vulnerable: bool):

--- a/src/objects/player.gd
+++ b/src/objects/player.gd
@@ -209,7 +209,7 @@ func draw_back():
 	is_drawing_back = true
 	if fov_tween:
 		fov_tween.kill()
-	fov_tween = get_tree().create_tween()
+	fov_tween = create_tween()
 	fov_tween.tween_property(camera, "fov", normal_fov + DRAWBACK_FOV_OFFSET, 2.0)
 
 
@@ -228,12 +228,12 @@ func release(is_cancel := false):
 	is_drawing_back = false
 	if fov_tween:
 		fov_tween.kill()
-	fov_tween = get_tree().create_tween()
+	fov_tween = create_tween()
 	fov_tween.tween_property(camera, "fov", normal_fov, 0.2)
 	if not is_cancel:
 		emit_signal("shoot", get_shot_power())
 	var duration := 0.25 * pow(get_shot_power(), 0.25)
-	get_tree().create_tween().tween_property(self, "drawback_time", 0.0, duration)
+	create_tween().tween_property(self, "drawback_time", 0.0, duration)
 
 
 func on_raycast_hit(peer_id: int):

--- a/src/states/game.gd
+++ b/src/states/game.gd
@@ -70,7 +70,7 @@ func _ready() -> void:
 	Multiplayer.server_disconnected.connect(server_disconnected)
 
 	if is_multiplayer_authority():
-		Multiplayer.all_players_ready.connect(self.on_all_players_ready)
+		Multiplayer.all_players_ready.connect(on_all_players_ready)
 	Multiplayer.rpc_id(1, "player_is_ready")
 
 
@@ -153,8 +153,8 @@ func spawn_player() -> void:
 	my_player.get_node("Camera3D").current = true
 	$Players.add_child(my_player)
 	Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
-	my_player.shoot.connect(self.i_would_like_to_shoot.bind(my_player.name))
-	my_player.melee_attack.connect(self.melee_attack.bind(my_player.name))
+	my_player.shoot.connect(i_would_like_to_shoot.bind(my_player.name))
+	my_player.melee_attack.connect(melee_attack.bind(my_player.name))
 	if is_multiplayer_authority():
 		my_player.player_death.connect(assign_spawn_point.bind(self_peer_id))
 		my_player.player_spawn.connect(clear_spawn_point.bind(self_peer_id))
@@ -257,7 +257,7 @@ func spawn_arrow(id: String, power: float) -> void:
 	new_arrow.transform = player_head.get_global_transform()
 	var shot_speed := BASE_SHOT_SPEED + (MAX_SHOT_SPEED - BASE_SHOT_SPEED) * power
 	new_arrow.velocity = shot_speed * -player_head.get_global_transform().basis.z.normalized()
-	new_arrow.spawn_pickup.connect(self.on_arrow_pickup_spawn)
+	new_arrow.spawn_pickup.connect(on_arrow_pickup_spawn)
 	arrows.add_child(new_arrow)
 	if arrows.get_child_count() > MAX_ARROWS_LOADED:
 		arrows.get_child(0).queue_free()
@@ -273,7 +273,7 @@ func on_arrow_pickup_spawn(spawn_transform: Transform3D) -> void:
 func spawn_arrow_pickup(spawn_transform: Transform3D) -> void:
 	var new_arrow_pickup := ArrowPickup.instantiate()
 	new_arrow_pickup.position = spawn_transform.origin
-	new_arrow_pickup.arrow_collected.connect(self.arrow_collected)
+	new_arrow_pickup.arrow_collected.connect(arrow_collected)
 	$ArrowPickups.add_child(new_arrow_pickup)
 
 

--- a/src/states/menus/credits_menu.gd
+++ b/src/states/menus/credits_menu.gd
@@ -1,6 +1,54 @@
 extends Control
 
+
 signal change_menu
+
+var main_licenses := [
+	["Godot Engine", Engine.get_license_text()],
+	["Kenney Assets", "This project uses assets created/distributed by Kenney (www.kenney.nl)\n\nLicensed under CC0:\nhttps://creativecommons.org/publicdomain/zero/1.0/"]
+]
+
+@onready var licenses_label: RichTextLabel = %LicensesLabel
+@onready var third_party_label: RichTextLabel = %ThirdPartyLabel
+
+
+func _ready() -> void:
+	licenses_label.push_font_size(14)
+	licenses_label.push_outline_color(Color.BLACK)
+	var first := true
+	for license in main_licenses:
+		if first:
+			first = false
+		else:
+			licenses_label.append_text("\n\n")
+		licenses_label.append_text("[center][font_size=21][outline_size=8][b]" + license[0] + "[/b][/outline_size][/font_size][/center]\n\n")
+		licenses_label.append_text(license[1])
+	licenses_label.pop()
+	licenses_label.pop()
+
+	# These engine license/copyright functions are not incredibly obvious how to usefully extract information from.
+	# This is similar to how it's done in the "About Godot" -> "Third-party Licenses" -> "All Components" screen
+	third_party_label.push_font_size(11)
+	third_party_label.push_outline_color(Color.BLACK)
+	first = true
+	for info in Engine.get_copyright_info():
+		if first:
+			first = false
+		else:
+			third_party_label.append_text("\n\n")
+		third_party_label.append_text("[center][font_size=15]" + info.name + "[/font_size][/center]\n")
+		for part: Dictionary in info.parts:
+			for copyright: String in part.copyright:
+				third_party_label.append_text("\n(c) " + copyright)
+			third_party_label.append_text("\nLicense: " + part.license)
+
+	var engine_licenses := Engine.get_license_info()
+	for license: String in engine_licenses:
+		third_party_label.append_text("\n\n[center][font_size=15]" + license + "[/font_size][/center]\n\n")
+		third_party_label.append_text(engine_licenses[license])
+	third_party_label.pop()
+	third_party_label.pop()
+
 
 func back_to_menu() -> void:
 	emit_signal("change_menu", "main_menu")

--- a/src/states/menus/credits_menu.tscn
+++ b/src/states/menus/credits_menu.tscn
@@ -33,67 +33,57 @@ size_flags_vertical = 4
 theme_override_font_sizes/normal_font_size = 18
 theme_override_font_sizes/bold_font_size = 32
 bbcode_enabled = true
-text = "[center][b]Terry Hearst[/b]
+text = "[center]
+[outline_color=black]
+[outline_size=12][b]Terry Hearst[/b][/outline_size]
 Programming
 Design
 
-[b]Andrew Moore[/b]
+[outline_size=12][b]Andrew Moore[/b][/outline_size]
 Programming
 Design
 Sound Effects
 
-[b]Kyle Reese[/b]
+[outline_size=12][b]Kyle Reese[/b][/outline_size]
 Programming
-Design"
+Design
+[/outline_color]
+[/center]"
 fit_content = true
 
-[node name="PanelContainer" type="PanelContainer" parent="M/H"]
+[node name="TabContainer" type="TabContainer" parent="M/H"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="MarginContainer" type="MarginContainer" parent="M/H/PanelContainer"]
+[node name="Licenses" type="MarginContainer" parent="M/H/TabContainer"]
 layout_mode = 2
-theme_override_constants/margin_left = 25
-theme_override_constants/margin_top = 25
-theme_override_constants/margin_right = 25
-theme_override_constants/margin_bottom = 25
+theme_override_constants/margin_left = 12
+theme_override_constants/margin_top = 12
+theme_override_constants/margin_right = 12
+theme_override_constants/margin_bottom = 12
 
-[node name="Licenses" type="RichTextLabel" parent="M/H/PanelContainer/MarginContainer"]
+[node name="LicensesLabel" type="RichTextLabel" parent="M/H/TabContainer/Licenses"]
+unique_name_in_owner = true
 layout_mode = 2
 bbcode_enabled = true
-text = "Licenses
 
-Godot Engine
-This game uses Godot Engine, available under the following license:
+[node name="All Third Party Licenses" type="MarginContainer" parent="M/H/TabContainer"]
+visible = false
+layout_mode = 2
+theme_override_constants/margin_left = 12
+theme_override_constants/margin_top = 12
+theme_override_constants/margin_right = 12
+theme_override_constants/margin_bottom = 12
 
-Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur. Copyright (c) 2014-2022 Godot Engine contributors.
+[node name="ThirdPartyLabel" type="RichTextLabel" parent="M/H/TabContainer/All Third Party Licenses"]
+unique_name_in_owner = true
+layout_mode = 2
+bbcode_enabled = true
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-FreeType
-Portions of this software are copyright © 1996-2022 The FreeType Project (www.freetype.org). All rights reserved.
-
-ENet
-Copyright (c) 2002-2020 Lee Salzman
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-mbed TLS
-Copyright The Mbed TLS Contributors
-
-Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License."
+[node name="PanelContainer" type="PanelContainer" parent="M/H"]
+visible = false
+layout_mode = 2
+size_flags_horizontal = 3
 
 [node name="BackButton" type="Button" parent="M"]
 custom_minimum_size = Vector2(100, 0)

--- a/src/states/menus/fancy_button.gd
+++ b/src/states/menus/fancy_button.gd
@@ -36,10 +36,10 @@ func on_button_press() -> void:
 func on_button_enter() -> void:
 	if button.disabled:
 		return
-	get_tree().create_tween().tween_property(spacer, "custom_minimum_size", OFFSET_MAX_SIZE, 0.1)
+	create_tween().tween_property(spacer, "custom_minimum_size", OFFSET_MAX_SIZE, 0.1)
 
 
 func on_button_exit() -> void:
 	if button.disabled:
 		return
-	get_tree().create_tween().tween_property(spacer, "custom_minimum_size", OFFSET_MIN_SIZE, 0.1)
+	create_tween().tween_property(spacer, "custom_minimum_size", OFFSET_MIN_SIZE, 0.1)

--- a/src/states/menus/menu.gd
+++ b/src/states/menus/menu.gd
@@ -8,9 +8,9 @@ extends Control
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	main_menu.change_menu.connect(self.show_menu)
-	credits_menu.change_menu.connect(self.show_menu)
-	lobby.change_menu.connect(self.show_menu)
+	main_menu.change_menu.connect(show_menu)
+	credits_menu.change_menu.connect(show_menu)
+	lobby.change_menu.connect(show_menu)
 	show_menu(Global.menu_to_load)
 
 


### PR DESCRIPTION
* Remove unnecessary `self.` in signal connections (Leftover godot3ism)
* `create_tween()` over `get_tree().create_tween()`
* Improved credits screen with proper licenseing
* Add gdignore file to python directory so those aren't exported or processed by Godot